### PR TITLE
Add time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.1",
     "moment": "^2.29.1",
+    "moment-timezone": "^0.5.33",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import CountdownForm from './components/CountdownForm';
 import './App.css';
 import { useEffect, useState } from 'react';
 import axios from 'axios'
+import moment from 'moment-timezone';
 
 function App() {
    const [countdowns, setCountdowns] = useState([])
@@ -13,6 +14,12 @@ function App() {
   const refreshCountdowns = () => {
     return axios.get(`${API_BASE_URL}/countdowns`)
     .then((response) => {
+      for (let countdown of response.data) {
+        // creating new moment object with the 
+        // supplied countdown_till_date
+        let date = moment(countdown.countdown_till_date)
+        countdown.countdown_till_date = date.format("YYYY-MM-DDTHH:mm:ssZ")
+      }
       setCountdowns(response.data)
       setErrorMessage('');
     }).catch((error) => {
@@ -23,8 +30,16 @@ function App() {
   useEffect(() => {
     refreshCountdowns()
   }, []);
+  const isISODate = (date) => {
+    let dateParsed = new Date(Date.parse(date));
+    return (dateParsed.toISOString() === date)
+  }
 
   const createCowndown = (newCountdown) => {
+    let date = newCountdown.countdown_till_date
+    if(!isISODate(date)){
+      console.log("ISOString format error", date)
+    }
     return axios.post(`${API_BASE_URL}/countdowns`, newCountdown).then((response) => {
       refreshCountdowns()
     })
@@ -45,9 +60,7 @@ function App() {
   return (
     <div className="App">
       <h1>Countdown Clock App</h1>
-      <div>
-
-      </div>
+  
       <h1>{errorMessage}</h1>
       <CountdownForm 
         addCountdownCallback={createCowndown}

--- a/src/components/Countdown.css
+++ b/src/components/Countdown.css
@@ -1,6 +1,6 @@
 .countdown {
     border: 2px solid black;
-    width: 25%;
+    width: 30%;
     padding: 8px;
     margin: 10px;
 }

--- a/src/components/Countdown.js
+++ b/src/components/Countdown.js
@@ -82,8 +82,8 @@ const Countdown = (props) => {
                 <button className="edit-button" onClick={props.handleEdit}>edit</button>
                 <button className="delete-button" onClick={props.onDelete}>🗑</button>
             </span>
-            <h3>{countdown.title}</h3>
-            <p>Countdown: {countdown.countdown_till_date}</p>
+            <h2>{countdown.title}</h2>
+            <p>{moment(countdown.countdown_till_date).format("LLL")}</p>
             <TimeLeft countdown_till_date={countdown.countdown_till_date}/> 
         </div>
         }

--- a/src/components/Countdown.js
+++ b/src/components/Countdown.js
@@ -42,42 +42,6 @@ const Countdown = (props) => {
         }).then(props.refreshCountdowns).then(props.cancelEdit)
     };
 
-    const calculateTimeLeft = (countdown) => {
-        let target = moment(countdown.countdown_till_date)
-        let current = moment.now()
-        let days = target.diff(current, 'days');
-        let years = target.diff(current, 'years')
-        let hours = target.diff(current, 'hours')
-        let minutes = target.diff(current, "minutes")
-        let seconds = target.diff(current, 'seconds')
-
-        // Keeping this here for comparison of
-        // using table for display purposes.
-        return(
-            <div>
-                <table>
-                    <tbody>
-                        <tr>
-                            <th>Years</th>
-                            <th>Days</th>
-                            <th>Hours</th>
-                            <th>Minutes</th>
-                            <th>Seconds</th>
-                        </tr>
-                        <tr>
-                            <td>{`${years}`}</td>
-                            <td>{`${days}`}</td>
-                            <td>{`${hours}`}</td>
-                            <td>{`${minutes}`}</td>
-                            <td>{`${seconds}`}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        )
-    }
-
-
     return (
     <div className="countdown-edit-form">
         {props.editMode ?
@@ -120,7 +84,6 @@ const Countdown = (props) => {
             </span>
             <h3>{countdown.title}</h3>
             <p>Countdown: {countdown.countdown_till_date}</p>
-            {calculateTimeLeft(countdown)}
             <TimeLeft countdown_till_date={countdown.countdown_till_date}/> 
         </div>
         }

--- a/src/components/CountdownForm.js
+++ b/src/components/CountdownForm.js
@@ -68,6 +68,7 @@ const CountdownForm = (props) => {
                     value={formFields.date}
                 />
                 {/* surrounded in div to keep it off same line. TO DO: accomplish with css*/}
+                
                 <div>
                     <label htmlFor="time">Time</label>
                 </div>

--- a/src/components/CountdownForm.js
+++ b/src/components/CountdownForm.js
@@ -1,11 +1,13 @@
 import './CountdownForm.css';
+import moment from 'moment-timezone';
 
 import { useState } from "react";
 
 const CountdownForm = (props) => {    
     const [formFields, setFormFields] = useState({
         "title": "",
-        "countdown_till_date": ""
+        "date": "",
+        "time": ""
     })
 
     const onTitleChange = (event) => {
@@ -18,30 +20,37 @@ const CountdownForm = (props) => {
     const onDateChange = (event) => {
         setFormFields({
             ...formFields,
-            countdown_till_date: event.target.value
+            date: event.target.value
         })
     };
+
+    const onTimeChange = (event) => {
+        setFormFields({
+            ...formFields,
+            time: event.target.value
+        })
+    }
 
     const onFormSubmit = (event) => {
         event.preventDefault();
 
         props.addCountdownCallback({
             title: formFields.title,
-            countdown_till_date: formFields.countdown_till_date
+            countdown_till_date: moment(formFields.date + "T" + formFields.time + ":00" + moment.tz(moment.tz.guess()).format('Z')).toISOString()
         });
 
         setFormFields({
             title: "",
-            countdown_till_date: ""
+            date: "",
+            time: ""
         })
     };
-
+ 
     return (
         <div className="countdown-form">
             <form onSubmit={onFormSubmit}>
                 
                 <label htmlFor="title">Countdown Title</label>
-
                 <input
                     id="countdown-title"
                     name="title" 
@@ -51,13 +60,23 @@ const CountdownForm = (props) => {
                 />
 
                 <label>Countdown Till Date</label>
-
                 <input 
                     id="countdown-date"
                     name="countdown-till-date"
                     onChange={onDateChange}
                     type="date"
-                    value={formFields.countdown_till_date}
+                    value={formFields.date}
+                />
+                {/* surrounded in div to keep it off same line. TO DO: accomplish with css*/}
+                <div>
+                    <label htmlFor="time">Time</label>
+                </div>
+                <input 
+                    id="countdown-time"
+                    name="countdown-till-time"
+                    onChange={onTimeChange}
+                    type="time"
+                    value={formFields.time}
                 />
                 <input type="submit" value="Create Countdown"  />
             </form>

--- a/src/components/CountdownList.js
+++ b/src/components/CountdownList.js
@@ -34,14 +34,13 @@ const CountdownList = (props) => {
                                     handleEdit={() => handleEdit(countdown)}
                                     cancelEdit={() => cancelEdit(countdown)}
                                     refreshCountdowns={props.refreshCountdowns}
-                                /> 
-                        </div>
+                                />
+                            </div>
                     )
                 })}
             </div>
         </section>
     )
-
 }
 
 export default CountdownList;

--- a/src/components/TimeLeft.css
+++ b/src/components/TimeLeft.css
@@ -1,0 +1,3 @@
+.time-left-container {
+    display: flex;
+}

--- a/src/components/TimeLeft.js
+++ b/src/components/TimeLeft.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import moment from 'moment';
+import './TimeLeft.css';
 
 const TimeLeft = (props) => {
     const [date, setDate] = useState(new Date());
@@ -22,7 +23,7 @@ const TimeLeft = (props) => {
 
         if (milliseconds > 0) {
             return(
-                <div>
+                <div className="time-left-container">
                     <section>{diff._data.years} years</section>
                     <section>{diff._data.months} months</section>
                     <section>{diff._data.days} days</section>

--- a/src/components/TimeLeft.js
+++ b/src/components/TimeLeft.js
@@ -41,7 +41,7 @@ const TimeLeft = (props) => {
 
     return (
         <div>
-            <h2>Time Left</h2>
+            <h4>Time Left</h4>
             {calculateTimeLeft(props.countdown_till_date)}
         </div>
     )

--- a/src/components/TimeLeft.js
+++ b/src/components/TimeLeft.js
@@ -16,31 +16,25 @@ const TimeLeft = (props) => {
     }
     const calculateTimeLeft = (countdown) => {
         let target = moment(props.countdown_till_date)
-        let current = moment.now()
-        let years = target.diff(current, 'years')
+        let current = moment()
+        let diff = moment.duration(target.diff(current))
         let milliseconds = target.diff(current, 'milliseconds')
-        if (milliseconds < 0) {
-            return (
-                <div>Countdown is up!!</div>
+
+        if (milliseconds > 0) {
+            return(
+                <div>
+                    <section>{diff._data.years} years</section>
+                    <section>{diff._data.months} months</section>
+                    <section>{diff._data.days} days</section>
+                    <section>{diff._data.hours} hours</section>
+                    <section>{diff._data.minutes} minutes</section>
+                    <section>{diff._data.seconds} seconds</section>
+                </div>
             )
         }
-
-        let yearDiff = "" + years;
-        let monthDiff = moment(milliseconds).format("M") - 1;
-        let dayDiff = moment(milliseconds).format("D"); 
-        let hourDiff = moment(milliseconds).format("H");
-        let minDiff = moment(milliseconds).format("mm");
-        let secDiff = moment(milliseconds).format("ss");
-
-        return(
-            <div>
-                <section>{yearDiff} Years(s)</section>
-                <section>{monthDiff} Months(s)</section>
-                <section>{dayDiff} Day(s)</section>
-                <section>{hourDiff} Hour(s)</section>
-                <section>{minDiff}Minute(s)</section>
-                <section>{secDiff} Second(s)</section>
-            </div>
+        return (
+            // TODO: Create display for completed or past events.
+            <div>Countdown Complete!</div>
         )
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7242,7 +7242,14 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.29.1:
+moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Countdown Form now has input dedicated to time element.

Taking in the time element allows me to have countdowns that will be able to truly countdown to a particular moment. Otherwise all countdowns would go off at midnight.

Essentially taking in time input and smooshing that time into my previously created DateTime object. Thus, allowing me the desired precision and keeping my current Backend API as is.  

<kbd>
<img src="https://user-images.githubusercontent.com/10947272/127254881-fa5fbd0e-1fc8-4ce1-b011-f6579c487ed5.png"
width=600px />
</kbd>